### PR TITLE
feat: YAML構文にStructWrapper型を導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 YAMLファイルでEEPROMマップを定義し、対応するC言語の構造体 (`.h`) を生成するツールです。
 
-## 📦 使用方法
+## 💼 使用方法
 
 ```powershell
 cargo run -- examples\eeprom.yaml
@@ -24,50 +24,26 @@ cargo run -- examples\eeprom.yaml
 
 ### 🔹 型定義の方法
 
-#### ▶ プリミティブ型
+#### ✅ サポートされるプリミティブ型
 
-```yaml
-- name: device_id
-  offset: 0
-  type: uint16
-```
+| 型名       | 説明          |
+| -------- | ----------- |
+| `uint8`  | 8ビット符号なし整数  |
+| `uint16` | 16ビット符号なし整数 |
+| `uint32` | 32ビット符号なし整数 |
 
-#### ▶ ネスト構造体（inline）
+本ツールは、型を自動で判別・補正する機能を備えています。
+そのため `type: uint8` のように文字列で指定した場合も、プリミティブ型やユーザー定義型として自動で解釈されます。
 
-```yaml
-- name: settings
-  offset: 10
-  type:
-    struct:
-      - name: brightness
-        offset: 0
-        type: uint8
-      - name: volume
-        offset: 1
-        type: uint8
-```
+次のYAMLファイルがそれぞれの型定義方法のサンプルとして提供されています：
 
-#### ▶ 事前定義構造体（custom）
+* [primitive.yaml](examples/primitive.yaml)：プリミティブ型の定義例
+* [nested\_struct.yaml](examples/nested_struct.yaml)：ネスト構造体（inline定義）
+* [custom\_autodetect.yaml](examples/custom_autodetect.yaml)：カスタム型（補正対応）の定義例
 
-```yaml
-types:
-  settings:
-    - name: brightness
-      offset: 0
-      type: uint8
-    - name: volume
-      offset: 1
-      type: uint8
+各形式の詳細はこれらのファイルをご参照ください。
 
-entries:
-  - name: settings
-    offset: 10
-    type: !custom settings
-```
-
-※ YAMLタグ `!custom` により `settings` を事前定義型として展開
-
-## 🗂 出力例（eeprom\_map.h）
+## 📂 出力例（eeprom\_map.h）
 
 ```c
 typedef struct {

--- a/examples/custom_autodetect.yaml
+++ b/examples/custom_autodetect.yaml
@@ -1,0 +1,18 @@
+version: 1
+base_address: 0
+endianness: little
+
+types:
+  settings:
+    - name: brightness
+      offset: 0
+      type: uint8
+    - name: volume
+      offset: 1
+      type: uint8
+
+entries:
+  - name: settings
+    offset: 10
+    type: settings
+    description: 自動補正されるカスタム構造体

--- a/examples/nested_struct.yaml
+++ b/examples/nested_struct.yaml
@@ -5,10 +5,11 @@ endianness: little
 entries:
   - name: settings
     offset: 0
-    type: !struct
-      - name: brightness
-        offset: 0
-        type: uint8
-      - name: volume
-        offset: 1
-        type: uint8
+    type:
+      struct:
+        - name: brightness
+          offset: 0
+          type: uint8
+        - name: volume
+          offset: 1
+          type: uint8

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -29,12 +29,18 @@ fn generate_struct(name: &str, fields: &[Entry], map: &EepromMap, visited: &mut 
             Type::Uint8 => "uint8_t".to_string(),
             Type::Uint16 => "uint16_t".to_string(),
             Type::Uint32 => "uint32_t".to_string(),
-            Type::Struct(subfields) => {
+            Type::StructWrapper { r#struct: subfields } => {
                 let subname = format!("{}_t", field.name);
                 generate_struct(&field.name, subfields, map, visited, output);
                 subname
             }
             Type::Custom(s) => {
+                if let Some(custom_fields) = map.types.get(s) {
+                    generate_struct(s, custom_fields, map, visited, output);
+                }
+                format!("{}_t", s)
+            }
+            Type::CustomCandidate(s) => {
                 if let Some(custom_fields) = map.types.get(s) {
                     generate_struct(s, custom_fields, map, visited, output);
                 }
@@ -54,7 +60,7 @@ pub fn generate_c_structs(map: &EepromMap) -> String {
     let mut visited = HashSet::new();
 
     for entry in &map.entries {
-        if let Type::Struct(ref fields) = entry.ty {
+        if let Type::StructWrapper { r#struct: fields } = &entry.ty {
             generate_struct(&entry.name, fields, map, &mut visited, &mut output);
         } else if let Type::Custom(ref name) = entry.ty {
             if let Some(fields) = map.types.get(name) {
@@ -83,8 +89,9 @@ pub fn generate_c_structs(map: &EepromMap) -> String {
             Type::Uint8 => "uint8_t".to_string(),
             Type::Uint16 => "uint16_t".to_string(),
             Type::Uint32 => "uint32_t".to_string(),
-            Type::Struct(_) => format!("{}_t", entry.name),
+            Type::StructWrapper { .. } => format!("{}_t", entry.name),
             Type::Custom(s) => format!("{}_t", s),
+            Type::CustomCandidate(s) => format!("{}_t", s),
         };
         writeln!(output, "    {} {};", c_type, entry.name).unwrap();
         current_offset += size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod model;
 pub mod parser;
 pub mod utils;
 pub mod generator;
+pub mod resolver;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,5 @@
-mod model;
-mod parser;
-mod utils;
-mod generator;
-
-use crate::parser::load_yaml;
-use crate::generator::generate_c_structs;
+use yaml2_memory_mapper::parser::load_yaml;
+use yaml2_memory_mapper::generator::generate_c_structs;
 use std::fs::File;
 use std::io::Write;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use serde::Serialize;
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
@@ -22,7 +23,7 @@ pub enum Endianness {
     Big,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct Entry {
     pub name: String,
@@ -32,12 +33,15 @@ pub struct Entry {
     pub description: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum Type {
+    CustomCandidate(String),
     Uint8,
     Uint16,
     Uint32,
-    Struct(Vec<Entry>),
+    #[serde(rename_all = "snake_case")]
+    StructWrapper { r#struct: Vec<Entry> },
+    #[serde(rename = "custom")]
     Custom(String),
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,5 @@
 use crate::model::EepromMap;
+use crate::resolver::resolve_types;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
@@ -6,6 +7,7 @@ use std::path::Path;
 pub fn load_yaml<P: AsRef<Path>>(path: P) -> Result<EepromMap, Box<dyn std::error::Error>> {
     let file = File::open(path)?;
     let reader = BufReader::new(file);
-    let map: EepromMap = serde_yaml::from_reader(reader)?;
+    let mut map: EepromMap = serde_yaml::from_reader(reader)?;
+    resolve_types(&mut map)?;
     Ok(map)
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,0 +1,57 @@
+use crate::model::{EepromMap, Entry, Type};
+use std::collections::HashMap;
+
+pub fn resolve_types(map: &mut EepromMap) -> Result<(), String> {
+    let keys: Vec<String> = map.types.keys().cloned().collect();
+    for key in keys {
+        let types_snapshot = map.types.clone(); // 回避策: cloneで不変参照を確保
+        if let Some(fields) = map.types.get_mut(&key) {
+            for field in fields.iter_mut() {
+                resolve_type(&mut field.ty, &types_snapshot)?;
+            }
+        }
+    }
+
+    let types_snapshot = map.types.clone();
+    for entry in &mut map.entries {
+        resolve_type(&mut entry.ty, &types_snapshot)?;
+    }
+
+    Ok(())
+}
+
+fn resolve_type(ty: &mut Type, types: &HashMap<String, Vec<Entry>>) -> Result<(), String> {
+    match ty {
+        Type::StructWrapper { r#struct: fields } => {
+            for field in fields.iter_mut() {
+                resolve_type(&mut field.ty, types)?;
+            }
+            Ok(())
+        }
+        Type::Custom(name) => {
+            if !types.contains_key(name) {
+                Err(format!("Undefined custom type: {}", name))
+            } else {
+                Ok(())
+            }
+        }
+        Type::CustomCandidate(name) => {
+            match name.as_str() {
+                "uint8" => { *ty = Type::Uint8; Ok(()) }
+                "uint16" => { *ty = Type::Uint16; Ok(()) }
+                "uint32" => { *ty = Type::Uint32; Ok(()) }
+                _ => {
+                    if types.contains_key(name) {
+                        *ty = Type::Custom(name.clone());
+                        Ok(())
+                    } else {
+                        Err(format!("Unknown type '{}'", name))
+                    }
+                }
+            }
+        }
+        Type::Uint8 | Type::Uint16 | Type::Uint32 => Ok(()),
+    }
+}
+
+

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ pub fn size_of(ty: &Type) -> usize {
         Type::Uint8 => 1,
         Type::Uint16 => 2,
         Type::Uint32 => 4,
-        Type::Struct(fields) => {
+        Type::StructWrapper { r#struct: fields } => {
             let mut offset = 0;
             for field in fields {
                 let field_size = size_of(&field.ty);
@@ -19,6 +19,7 @@ pub fn size_of(ty: &Type) -> usize {
             offset
         },
         Type::Custom(_) => 0, // 解決されるまで未定義
+        Type::CustomCandidate(_) => 0, // 解決されるまで未定義
     }
 }
 

--- a/tests/validate_yaml.rs
+++ b/tests/validate_yaml.rs
@@ -1,4 +1,3 @@
-// tests/validate_yaml.rs
 use std::path::Path;
 use yaml2_memory_mapper::parser::load_yaml;
 
@@ -14,4 +13,11 @@ fn validate_nested_struct_yaml() {
     let path = Path::new("examples/nested_struct.yaml");
     let result = load_yaml(path);
     assert!(result.is_ok(), "Failed to parse nested_struct.yaml: {:?}", result.err());
+}
+
+#[test]
+fn validate_custom_autodetect_yaml() {
+    let path = Path::new("examples/custom_autodetect.yaml");
+    let result = load_yaml(path);
+    assert!(result.is_ok(), "Failed to parse custom_autodetect.yaml: {:?}", result.err());
 }


### PR DESCRIPTION
## 概要

このPull Requestでは、以下の変更を含みます：

- YAMLの `type:` フィールドで `struct:` によるネスト構造体定義をサポート（`StructWrapper` を新規導入）
- YAMLロード直後に型補正を行う `resolve_types()` 処理を追加
- プリミティブ型・カスタム型の自動補正（uint8 等）を可能に
- それに伴うgenerator/utils/resolverの対応実装
- テスト用YAMLファイル（primitive.yaml, custom_autodetect.yaml, nested_struct.yaml）を整備
- READMEに以下を追記：
  - 対応型一覧（uint8, uint16, uint32）
  - サンプルYAMLファイルへの参照リンク

## 目的

柔軟な型定義の許容と、構文の明示的な文書化を進めることで、利用者の記述負担を軽減し、ツールの堅牢性を向上させる。

## 関連ファイル

- `model.rs`, `resolver.rs`, `generator.rs`, `utils.rs`
- `examples/*.yaml`
- `README.md`
- `tests/validate_yaml.rs`

